### PR TITLE
(PE-19513) SLES 12 SP2 Higgs support

### DIFF
--- a/lib/chloride/action/detect_platform.rb
+++ b/lib/chloride/action/detect_platform.rb
@@ -37,7 +37,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
                          :rhel
                        when /amazonami/
                          :amazon
-                       when /suselinux/
+                       when /suse/
                          :sles
                        else
                          distribution.to_sym
@@ -45,7 +45,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
 
         release = lsb_data['Release'].gsub(/\s+/, '')
         release = case distribution
-                  when :centos, :rhel
+                  when :centos, :rhel, :sles
                     release.split('.')[0]
                   when :debian
                     if release == 'testing'


### PR DESCRIPTION
Prior to this patch, the detect_platform regex would overlook
the "SUSE" string returned from lsb_release in SLES 12 SP2.
It also would fail to split the minor release number from the
release string.  This patch brings SLES support in line with
RHEL by stripping the minor version on the check and accepting
all known SuSE platform strings.