### PR TITLE
Fix rubocop, relax dev gem deps, re-enable linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+AllCops:
+  TargetRubyVersion: 2.4
+
 # Offense count: 6
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:
@@ -364,3 +367,20 @@ Style/WordArray:
 # Cop supports --auto-correct.
 Style/ZeroLengthPredicate:
   AutoCorrect: true
+
+# I'll be a terse as I want to
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
+# Don't like the %i style.
+Style/SymbolArray:
+  Enabled: false
+
+# if code_is_poetry
+#   make_a_block_if_you_want_to
+# end
+Style/IfUnlessModifier:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require 'rubocop/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new(:lint)
 
-task default: [:spec]
+task default: [:spec, :lint]

--- a/bin/go_execute
+++ b/bin/go_execute
@@ -17,7 +17,7 @@ opt_parse = OptionParser.new do |opts|
 end
 
 if ARGV.length < 2
-  opt_parse.parse!(%w(--help))
+  opt_parse.parse!(%w[--help])
 else
   hostname = ARGV[0]
   command = ARGV[1]

--- a/chloride.gemspec
+++ b/chloride.gemspec
@@ -23,12 +23,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'pry-coolline', '~> 0.2'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 11'
   spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'rubocop', '~> 0.44'
-  spec.add_development_dependency 'simplecov', '~> 0.12'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'simplecov'
   spec.add_dependency 'net-scp', '~> 1'
   spec.add_dependency 'net-ssh', '~> 4'
 end

--- a/chloride.gemspec
+++ b/chloride.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'chloride/version'
 
@@ -24,12 +23,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'rake', '~> 11'
-  spec.add_development_dependency 'rspec', '~> 3'
-  spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'pry-coolline', '~> 0.2'
+  spec.add_development_dependency 'rake', '~> 11'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop', '~> 0.44'
-  spec.add_dependency 'net-ssh', '~> 4'
+  spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_dependency 'net-scp', '~> 1'
+  spec.add_dependency 'net-ssh', '~> 4'
 end

--- a/lib/chloride.rb
+++ b/lib/chloride.rb
@@ -35,13 +35,13 @@ module Chloride
     host = Chloride::Host.new(hostname)
     host.ssh_connect
 
-    action_class = case action
-    when 'file_copy'
-      opts[:to_host] = host
-      Chloride::Action::FileCopy
-    else
-      raise "Unknown or unsupported action #{action_class}"
-    end
+    action_class =  case action
+                    when 'file_copy'
+                      opts[:to_host] = host
+                      Chloride::Action::FileCopy
+                    else
+                      raise "Unknown or unsupported action #{action_class}"
+                    end
 
     remote_action = action_class.new(opts)
 

--- a/lib/chloride/action/detect_platform.rb
+++ b/lib/chloride/action/detect_platform.rb
@@ -127,7 +127,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (suse_release[:exit_status]).zero?
           stdout = suse_release[:stdout]
 
-          if /Enterprise Server/ =~ stdout
+          if stdout.match?(/Enterprise Server/)
             distribution = :sles
             release = /^VERSION = (\d*)/m.match(stdout)[1]
           end
@@ -141,7 +141,7 @@ class Chloride::Action::DetectPlatform < Chloride::Action
         if (system_release[:exit_status]).zero?
           stdout = system_release[:stdout]
 
-          if /amazon linux/im =~ stdout
+          if stdout.match?(/amazon linux/im)
             distribution = :amazon
             # How is this safe to assume?
             release = '6'

--- a/lib/chloride/executor.rb
+++ b/lib/chloride/executor.rb
@@ -6,7 +6,7 @@ class Chloride::Executor
 
   def publish(event, action_id = nil)
     event.action_id = action_id if action_id
-    @stream_block.call(event) if @stream_block
+    @stream_block&.call(event)
   end
 
   def execute(steps)

--- a/lib/chloride/ssh_known_hosts.rb
+++ b/lib/chloride/ssh_known_hosts.rb
@@ -1,3 +1,7 @@
+# Dummy KnownHosts implementation
+#
+# This exists to stop Net::SSH from writing to the user's known_hosts file
+# Instead, new host signatures are saved to a library-specific file.
 class Chloride::SSHKnownHosts < Net::SSH::KnownHosts
   # Method signatures inherited from Net::SSH::KnownHosts
   # def initialize(source)
@@ -9,9 +13,8 @@ class Chloride::SSHKnownHosts < Net::SSH::KnownHosts
   # def add(host, key, options={})
 
   # Must be implemented
-  def search_for(host, options={})
-    opts = {}.merge(options).merge(
-      {user_known_hosts_file: source})
+  def search_for(host, options = {})
+    opts = {}.merge(options).merge(user_known_hosts_file: source)
     Net::SSH::KnownHosts.search_for(host, opts)
   end
 end

--- a/spec/lib/chloride/executor.rb
+++ b/spec/lib/chloride/executor.rb
@@ -41,15 +41,15 @@ describe Chloride::Executor do
 
     shared_examples_for :step_failure do
       it 'sends a step_error event' do
-        expect(executed_events).to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+        expect(executed_events).to include(satisfy { |m| m.type == :step_error && m.name == :step1 })
       end
 
       it 'does not send a step_success event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_success && m.name == :step1 })
       end
 
       it 'does not send a step_warn event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_warn && m.name == :step1 })
       end
 
       it 'executes the remaining steps if the failed step is not fail-stop' do
@@ -70,17 +70,17 @@ describe Chloride::Executor do
         end
 
         it 'sends a step_skip event for the remaining steps' do
-          expect(executed_events).to include satisfy { |m| m.type == :step_skip && m.name == :step2 }
+          expect(executed_events).to include(satisfy { |m| m.type == :step_skip && m.name == :step2 })
         end
 
         it 'does not send a step_start event for the remaining steps' do
-          expect(executed_events).not_to include satisfy { |m| m.type == :step_start && m.name == :step2 }
+          expect(executed_events).not_to include(satisfy { |m| m.type == :step_start && m.name == :step2 })
         end
 
         it 'does not send any complete event for the remaining steps' do
-          expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step2 }
-          expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step2 }
-          expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step2 }
+          expect(executed_events).not_to include(satisfy { |m| m.type == :step_success && m.name == :step2 })
+          expect(executed_events).not_to include(satisfy { |m| m.type == :step_warn && m.name == :step2 })
+          expect(executed_events).not_to include(satisfy { |m| m.type == :step_error && m.name == :step2 })
         end
       end
     end
@@ -101,7 +101,7 @@ describe Chloride::Executor do
 
         it 'adds the exception as an error message' do
           event = executed_events.find { |m| m.type == :step_error && m.name == :step1 }
-          expect(event.messages).to include satisfy { |m| m.severity == :error && m.message =~ /An error occured while performing.*terribly, horribly awry!/ }
+          expect(event.messages).to include(satisfy { |m| m.severity == :error && m.message =~ /An error occured while performing.*terribly, horribly awry!/ })
         end
 
         it_behaves_like :step_failure
@@ -114,15 +114,15 @@ describe Chloride::Executor do
       end
 
       it 'sends a step_warn event' do
-        expect(executed_events).to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+        expect(executed_events).to include(satisfy { |m| m.type == :step_warn && m.name == :step1 })
       end
 
       it 'does not send a step_success event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_success && m.name == :step1 })
       end
 
       it 'does not send a step_error event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_error && m.name == :step1 })
       end
 
       it 'executes the remaining steps if the step is not fail-stop' do
@@ -140,15 +140,15 @@ describe Chloride::Executor do
 
     describe 'when a step has status success' do
       it 'sends a step_success event' do
-        expect(executed_events).to include satisfy { |m| m.type == :step_success && m.name == :step1 }
+        expect(executed_events).to include(satisfy { |m| m.type == :step_success && m.name == :step1 })
       end
 
       it 'does not send a step_error event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_error && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_error && m.name == :step1 })
       end
 
       it 'does not send a step_warn event' do
-        expect(executed_events).not_to include satisfy { |m| m.type == :step_warn && m.name == :step1 }
+        expect(executed_events).not_to include(satisfy { |m| m.type == :step_warn && m.name == :step1 })
       end
 
       it 'executes the remaining steps if the step is not fail-stop' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,5 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'spec'
 end
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'chloride'


### PR DESCRIPTION
f4df58c (Brandon High, 70 seconds ago)
   Re-enable lint and specs as default rake target

   Prior to this commit I disabled linting in the default rake task, because
   rubocop was very angry. This commit re-enables the linting, because rubocop
   is OK with everything now.

ec59631 (Brandon High, 2 minutes ago)
   Relax development dependency version requirements

   There's no reason to restrict these versions, now that the rubocop errors
   are fixed.

3835b29 (Brandon High, 7 minutes ago)
   Misc. Rubocop fixes