### PR TITLE
(maint) Unpin net-ssh and net-scp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ build-iPhoneSimulator/
 # Gemfile.lock
 # .ruby-version
 # .ruby-gemset
+Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -384,3 +384,8 @@ Style/IfUnlessModifier:
 
 Metrics/LineLength:
   Enabled: false
+
+# We're ok with using variable names (` Exception => err`) 
+#   for exceptions, not just `Exception => e`
+Naming/RescuedExceptionsVariableName:
+  Enabled: false

--- a/chloride.gemspec
+++ b/chloride.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.4'
 
-  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 11'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
-  spec.add_dependency 'net-scp', '~> 1'
-  spec.add_dependency 'net-ssh', '~> 4'
+  spec.add_dependency 'net-scp'
+  spec.add_dependency 'net-ssh'
 end


### PR DESCRIPTION
This commit unpins net-ssh and net-scp, and updates the .gitignore to
include the Gemfile.lock