### PR TITLE
(maint) Cleanup RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Lint/AssignmentInCondition:
   Exclude:
     - 'lib/chloride/host.rb'
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: true
 
 Lint/RescueException:
@@ -27,7 +27,7 @@ Lint/ShadowingOuterLocalVariable:
     - 'lib/chloride/host.rb'
 
 # Cop supports --auto-correct.
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
   AutoCorrect: true
 
@@ -75,12 +75,6 @@ Metrics/CyclomaticComplexity:
   Enabled: false
   Max: 20
 
-# Offense count: 90
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 237
-
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
@@ -91,22 +85,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
   Max: 23
-
-# Offense count: 10
-# Cop supports --auto-correct.
-Performance/RedundantBlockCall:
-  AutoCorrect: false
-  Exclude:
-    - 'lib/chloride/action.rb'
-    - 'lib/chloride/action/execute.rb'
-    - 'lib/chloride/action/file_copy.rb'
-    - 'lib/chloride/action/resolve_dns.rb'
-    - 'lib/chloride/host.rb'
-
-# Cop supports --auto-correct.
-Performance/TimesMap:
-  Enabled: true
-  AutoCorrect: true
 
 # Offense count: 3
 # Cop supports --auto-correct.
@@ -198,11 +176,6 @@ Style/GuardClause:
 # Configuration parameters: EnforcedStyle, SupportedStyles, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
 # SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
 Style/HashSyntax:
-  AutoCorrect: true
-
-# Cop supports --auto-correct.
-# Configuration parameters: MaxLineLength.
-Style/IfUnlessModifier:
   AutoCorrect: true
 
 # Configuration parameters: EnforcedStyle, SupportedStyles.
@@ -349,11 +322,11 @@ Style/UnlessElse:
   AutoCorrect: true
 
 # Cop supports --auto-correct.
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   AutoCorrect: true
 
 # Cop supports --auto-correct.
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   AutoCorrect: true
 
 # Cop supports --auto-correct.
@@ -369,7 +342,7 @@ Style/ZeroLengthPredicate:
   AutoCorrect: true
 
 # I'll be a terse as I want to
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 
 # Don't like the %i style.


### PR DESCRIPTION
This commit renames and removes some RuboCop cops. Previously, RuboCop was
failing with:
.rubocop.yml:205: `Style/IfUnlessModifier` is concealed by line 382
.rubocop.yml:81: `Metrics/LineLength` is concealed by line 385
Error: The `Lint/HandleExceptions` cop has been renamed to `Lint/SuppressedException`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Lint/StringConversionInInterpolation` cop has been renamed to `Lint/RedundantStringCoercion`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Naming/UncommunicativeMethodParamName` cop has been renamed to `Naming/MethodParameterName`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/UnneededInterpolation` cop has been renamed to `Style/RedundantInterpolation`.
(obsolete configuration found in .rubocop.yml, please update it)
The `Style/UnneededPercentQ` cop has been renamed to `Style/RedundantPercentQ`.
(obsolete configuration found in .rubocop.yml, please update it)
RuboCop failed!